### PR TITLE
Relabel prometheus metrics

### DIFF
--- a/prometheus.yml.tmpl
+++ b/prometheus.yml.tmpl
@@ -11,6 +11,11 @@ rule_files:
 
 scrape_configs:
   - job_name: 'prometheus'
+    metric_relabel_configs:
+    - source_labels: ["__name__"]
+      regex: "prometheus_.*"
+      target_label: "instance"
+      replacement: "{{.prometheusServer}}"
     static_configs:
     - targets: ['localhost:9090']
 


### PR DESCRIPTION
This add relabel_config on prometheus metrics. It shoud be accept if [pr](https://github.com/flaviostutz/promster/pull/11) it is accepted. 
Signed-off-by: Gustavo Coelho <gutorc@hotmail.com>