### PR TITLE
Removed special characters in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -86,7 +86,7 @@ fi
 
 if [[ "$ALERT_MANAGER_URLS" != "" ]]; then
     sed -i -e 's;$ALERT_RULES_FILE;'"- $ALERT_RULES_FILE"';g' "/prometheus.yml.tmpl"
-	sed -i "/alerting/,/    - targets: ['$ALERT_MANAGER_URLS']/d" "/prometheus.yml.tmpl"
+	sed -i "/alerting/,/targets: /d" "/prometheus.yml.tmpl"
 	cat >> "/prometheus.yml.tmpl" <<- EOM
 
 alerting:


### PR DESCRIPTION
The previous solution to fix the Prometheus reload didn't work in some machines. The reason was the command `sed` wasn't working with the special character in some cases. This PR removes the special characters, however, it's still working fine. 